### PR TITLE
queryDbRow

### DIFF
--- a/src/main/scala/com/dataintuitive/luciuscore/DbFunctions.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/DbFunctions.scala
@@ -10,12 +10,20 @@ object DbFunctions {
     * @param queries Rank vector(s)
     * @return Map, with DbRows' pwid as the key an a list of length(queries) as the value
     */
-  def queryDbRow(x: DbRow,
-                 queries: Array[Double]*): Map[Option[String], Seq[Option[Double]]] = {
+  def queryDbRowPwid(x: DbRow,
+                     queries: Array[Double]*): Map[Option[String], Seq[Option[Double]]] = {
     x.sampleAnnotations.r match {
       case Some(r) => Map(x.pwid ->
         queries.map(query => Option(connectionScore(r, query))))
       case _       => Map(None -> List(None))
+    }
+  }
+
+  def queryDbRow(x: DbRow,
+                     queries: Array[Double]*): Option[(DbRow, Seq[Double])] = {
+    x.sampleAnnotations.r match {
+      case Some(r) => Some(x, queries.map(query => connectionScore(r, query)))
+      case _       => None
     }
   }
 

--- a/src/main/scala/com/dataintuitive/luciuscore/DbFunctions.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/DbFunctions.scala
@@ -19,6 +19,12 @@ object DbFunctions {
     }
   }
 
+  /**
+    * Score an arbitrary number of rank vectors against a database entry.
+    * @param x DbRow
+    * @param queries Rank vector(s)
+    * @return List of Option-wrapped tuples (DbRow, Seq(scores))
+    */
   def queryDbRow(x: DbRow,
                      queries: Array[Double]*): Option[(DbRow, Seq[Double])] = {
     x.sampleAnnotations.r match {

--- a/src/main/scala/com/dataintuitive/luciuscore/DbFunctions.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/DbFunctions.scala
@@ -1,0 +1,22 @@
+package com.dataintuitive.luciuscore
+
+import com.dataintuitive.luciuscore.Model.DbRow
+import com.dataintuitive.luciuscore.ZhangScoreFunctions.connectionScore
+
+object DbFunctions {
+  /**
+    * Score an arbitrary number of rank vectors against a database entry.
+    * @param x DbRow
+    * @param queries Rank vector(s)
+    * @return Map, with DbRows' pwid as the key an a list of length(queries) as the value
+    */
+  def queryDbRow(x: DbRow,
+                 queries: Array[Double]*): Map[Option[String], Seq[Option[Double]]] = {
+    x.sampleAnnotations.r match {
+      case Some(r) => Map(x.pwid ->
+        queries.map(query => Option(connectionScore(r, query))))
+      case _       => Map(None -> List(None))
+    }
+  }
+
+}

--- a/src/main/scala/com/dataintuitive/luciuscore/ZhangScoreFunctions.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/ZhangScoreFunctions.scala
@@ -33,4 +33,19 @@ object ZhangScoreFunctions {
       .sum
   }
 
+  /**
+    * Score an arbitrary number of rank vectors against a database entry.
+    * @param x DbRow
+    * @param queries Rank vector(s)
+    * @return Map, with DbRows' pwid as the key an a list of length(queries) as the value
+    */
+  def queryDbRow(x: DbRow,
+                   queries: Array[Double]*): Map[Option[String], Seq[Option[Double]]] = {
+    x.sampleAnnotations.r match {
+      case Some(r) => Map(x.pwid ->
+        queries.map(query => Option(connectionScore(r, query))))
+      case _       => Map(None -> List(None))
+    }
+  }
+
 }

--- a/src/main/scala/com/dataintuitive/luciuscore/ZhangScoreFunctions.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/ZhangScoreFunctions.scala
@@ -33,19 +33,4 @@ object ZhangScoreFunctions {
       .sum
   }
 
-  /**
-    * Score an arbitrary number of rank vectors against a database entry.
-    * @param x DbRow
-    * @param queries Rank vector(s)
-    * @return Map, with DbRows' pwid as the key an a list of length(queries) as the value
-    */
-  def queryDbRow(x: DbRow,
-                   queries: Array[Double]*): Map[Option[String], Seq[Option[Double]]] = {
-    x.sampleAnnotations.r match {
-      case Some(r) => Map(x.pwid ->
-        queries.map(query => Option(connectionScore(r, query))))
-      case _       => Map(None -> List(None))
-    }
-  }
-
 }

--- a/src/test/scala/com/dataintuitive/luciuscore/DbFunctionsTest.scala
+++ b/src/test/scala/com/dataintuitive/luciuscore/DbFunctionsTest.scala
@@ -1,0 +1,35 @@
+package com.dataintuitive.luciuscore
+
+import com.dataintuitive.luciuscore.Model.{DbRow, RankVector, SampleAnnotations}
+import com.dataintuitive.luciuscore.io.SampleCompoundRelationsIO.loadSampleCompoundRelationsFromFileV2
+import com.dataintuitive.test.BaseSparkContextSpec
+import org.scalatest.FlatSpec
+import com.dataintuitive.luciuscore.DbFunctions._
+
+class DbFunctionsTest extends FlatSpec with BaseSparkContextSpec{
+  
+  info("Testing rank vector scoring")
+
+  // load relations data in order to get an example DbRow object
+  val sampleCompoundRelationsV2Source = "src/test/resources/v2/sampleCompoundRelations.txt"
+  val aDbRow = loadSampleCompoundRelationsFromFileV2(sc, sampleCompoundRelationsV2Source).first
+  // the example data does not have the r vectors we are testing, so construct new DbRow
+  val newDbRow = DbRow(aDbRow.pwid,
+    SampleAnnotations(aDbRow.sampleAnnotations.sample,
+      Some(Array(2.0, 2.0, 2.0, 2.0)),
+      Some(Array(2.0, 2.0, 2.0, 2.0)),
+      Some(Array(2.0, 2.0, 2.0, 2.0))),
+    aDbRow.compoundAnnotations)
+
+  "queryDbRow function" should "give a numerical value for a single query" in {
+    val x: RankVector = Array.fill(4){scala.util.Random.nextInt(10).asInstanceOf[Double]}
+    assert(queryDbRow(newDbRow, x).values.toSeq.head.head.get.isInstanceOf[Double] === true)
+  }
+
+  it should "give a list of size two for two queries" in {
+    val x: RankVector = Array.fill(4){scala.util.Random.nextInt(10).asInstanceOf[Double]}
+    val y: RankVector = Array.fill(4){scala.util.Random.nextInt(10).asInstanceOf[Double]}
+    assert(queryDbRow(newDbRow, x, y).values.toSeq.head.size === 2)
+  }
+
+}

--- a/src/test/scala/com/dataintuitive/luciuscore/DbFunctionsTest.scala
+++ b/src/test/scala/com/dataintuitive/luciuscore/DbFunctionsTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.FlatSpec
 import com.dataintuitive.luciuscore.DbFunctions._
 
 class DbFunctionsTest extends FlatSpec with BaseSparkContextSpec{
-  
+
   info("Testing rank vector scoring")
 
   // load relations data in order to get an example DbRow object
@@ -23,13 +23,13 @@ class DbFunctionsTest extends FlatSpec with BaseSparkContextSpec{
 
   "queryDbRow function" should "give a numerical value for a single query" in {
     val x: RankVector = Array.fill(4){scala.util.Random.nextInt(10).asInstanceOf[Double]}
-    assert(queryDbRow(newDbRow, x).values.toSeq.head.head.get.isInstanceOf[Double] === true)
+    assert(queryDbRowPwid(newDbRow, x).values.toSeq.head.head.get.isInstanceOf[Double] === true)
   }
 
   it should "give a list of size two for two queries" in {
     val x: RankVector = Array.fill(4){scala.util.Random.nextInt(10).asInstanceOf[Double]}
     val y: RankVector = Array.fill(4){scala.util.Random.nextInt(10).asInstanceOf[Double]}
-    assert(queryDbRow(newDbRow, x, y).values.toSeq.head.size === 2)
+    assert(queryDbRowPwid(newDbRow, x, y).values.toSeq.head.size === 2)
   }
 
 }

--- a/src/test/scala/com/dataintuitive/luciuscore/DbFunctionsTest.scala
+++ b/src/test/scala/com/dataintuitive/luciuscore/DbFunctionsTest.scala
@@ -21,7 +21,7 @@ class DbFunctionsTest extends FlatSpec with BaseSparkContextSpec{
       Some(Array(2.0, 2.0, 2.0, 2.0))),
     aDbRow.compoundAnnotations)
 
-  "queryDbRow function" should "give a numerical value for a single query" in {
+  "queryDbRowPwid function" should "give a numerical value for a single query" in {
     val x: RankVector = Array.fill(4){scala.util.Random.nextInt(10).asInstanceOf[Double]}
     assert(queryDbRowPwid(newDbRow, x).values.toSeq.head.head.get.isInstanceOf[Double] === true)
   }
@@ -32,4 +32,15 @@ class DbFunctionsTest extends FlatSpec with BaseSparkContextSpec{
     assert(queryDbRowPwid(newDbRow, x, y).values.toSeq.head.size === 2)
   }
 
+  "queryDbRow function" should "give a numerical value for a single query" in {
+    val x: RankVector = Array.fill(4){scala.util.Random.nextInt(10).asInstanceOf[Double]}
+    assert(queryDbRow(newDbRow, x).get._2.head.isInstanceOf[Double] === true)
+  }
+
+  it should "give a list of size two for two queries" in {
+    val x: RankVector = Array.fill(4){scala.util.Random.nextInt(10).asInstanceOf[Double]}
+    val y: RankVector = Array.fill(4){scala.util.Random.nextInt(10).asInstanceOf[Double]}
+    assert(queryDbRow(newDbRow, x, y).get._2.size === 2)
+  }
+    
 }

--- a/src/test/scala/com/dataintuitive/luciuscore/ZhangScoreFunctionsTest.scala
+++ b/src/test/scala/com/dataintuitive/luciuscore/ZhangScoreFunctionsTest.scala
@@ -49,4 +49,10 @@ class ZhangScoreFunctionsTest extends FlatSpec with BaseSparkContextSpec {
     assert(queryDbRow(newDbRow, x).values.toSeq.head.head.get.isInstanceOf[Double] === true)
   }
 
+  it should "give a list of size two for two queries" in {
+    val x: RankVector = Array.fill(4){scala.util.Random.nextInt(10).asInstanceOf[Double]}
+    val y: RankVector = Array.fill(4){scala.util.Random.nextInt(10).asInstanceOf[Double]}
+    assert(queryDbRow(newDbRow, x, y).values.toSeq.head.size === 2)
+  }
+
 }

--- a/src/test/scala/com/dataintuitive/luciuscore/ZhangScoreFunctionsTest.scala
+++ b/src/test/scala/com/dataintuitive/luciuscore/ZhangScoreFunctionsTest.scala
@@ -2,7 +2,6 @@ package com.dataintuitive.luciuscore
 
 import com.dataintuitive.luciuscore.Model._
 import com.dataintuitive.luciuscore.ZhangScoreFunctions._
-import com.dataintuitive.luciuscore.io.SampleCompoundRelationsIO.loadSampleCompoundRelationsFromFileV2
 import com.dataintuitive.test.BaseSparkContextSpec
 import org.scalatest.FlatSpec
 
@@ -29,30 +28,6 @@ class ZhangScoreFunctionsTest extends FlatSpec with BaseSparkContextSpec {
     val x: RankVector = Array(3.0, 2.0, 1.0, 0.0)
     val y: RankVector = Array(3.0, 2.0, 1.0, 0.0)
     assert(connectionScore(x,y) === 1.0)
-  }
-
-  info("Testing rank vector scoring")
-
-  // load relations data in order to get an example DbRow object
-  val sampleCompoundRelationsV2Source = "src/test/resources/v2/sampleCompoundRelations.txt"
-  val aDbRow = loadSampleCompoundRelationsFromFileV2(sc, sampleCompoundRelationsV2Source).first
-  // the example data does not have the r vectors we are testing, so construct new DbRow
-  val newDbRow = DbRow(aDbRow.pwid,
-    SampleAnnotations(aDbRow.sampleAnnotations.sample,
-      Some(Array(2.0, 2.0, 2.0, 2.0)),
-      Some(Array(2.0, 2.0, 2.0, 2.0)),
-      Some(Array(2.0, 2.0, 2.0, 2.0))),
-    aDbRow.compoundAnnotations)
-
-  "queryDbRow function" should "give a numerical value for a single query" in {
-    val x: RankVector = Array.fill(4){scala.util.Random.nextInt(10).asInstanceOf[Double]}
-    assert(queryDbRow(newDbRow, x).values.toSeq.head.head.get.isInstanceOf[Double] === true)
-  }
-
-  it should "give a list of size two for two queries" in {
-    val x: RankVector = Array.fill(4){scala.util.Random.nextInt(10).asInstanceOf[Double]}
-    val y: RankVector = Array.fill(4){scala.util.Random.nextInt(10).asInstanceOf[Double]}
-    assert(queryDbRow(newDbRow, x, y).values.toSeq.head.size === 2)
   }
 
 }

--- a/src/test/scala/com/dataintuitive/luciuscore/ZhangScoreFunctionsTest.scala
+++ b/src/test/scala/com/dataintuitive/luciuscore/ZhangScoreFunctionsTest.scala
@@ -2,12 +2,14 @@ package com.dataintuitive.luciuscore
 
 import com.dataintuitive.luciuscore.Model._
 import com.dataintuitive.luciuscore.ZhangScoreFunctions._
+import com.dataintuitive.luciuscore.io.SampleCompoundRelationsIO.loadSampleCompoundRelationsFromFileV2
+import com.dataintuitive.test.BaseSparkContextSpec
 import org.scalatest.FlatSpec
 
 /**
   * Created by toni on 26/04/16.
   */
-class ZhangScoreFunctionsTest extends FlatSpec {
+class ZhangScoreFunctionsTest extends FlatSpec with BaseSparkContextSpec {
 
   info("Testing Connection score calculation")
 
@@ -27,6 +29,24 @@ class ZhangScoreFunctionsTest extends FlatSpec {
     val x: RankVector = Array(3.0, 2.0, 1.0, 0.0)
     val y: RankVector = Array(3.0, 2.0, 1.0, 0.0)
     assert(connectionScore(x,y) === 1.0)
+  }
+
+  info("Testing rank vector scoring")
+
+  // load relations data in order to get an example DbRow object
+  val sampleCompoundRelationsV2Source = "src/test/resources/v2/sampleCompoundRelations.txt"
+  val aDbRow = loadSampleCompoundRelationsFromFileV2(sc, sampleCompoundRelationsV2Source).first
+  // the example data does not have the r vectors we are testing, so construct new DbRow
+  val newDbRow = DbRow(aDbRow.pwid,
+    SampleAnnotations(aDbRow.sampleAnnotations.sample,
+      Some(Array(2.0, 2.0, 2.0, 2.0)),
+      Some(Array(2.0, 2.0, 2.0, 2.0)),
+      Some(Array(2.0, 2.0, 2.0, 2.0))),
+    aDbRow.compoundAnnotations)
+
+  "queryDbRow function" should "give a numerical value for a single query" in {
+    val x: RankVector = Array.fill(4){scala.util.Random.nextInt(10).asInstanceOf[Double]}
+    assert(queryDbRow(newDbRow, x).values.toSeq.head.head.get.isInstanceOf[Double] === true)
   }
 
 }


### PR DESCRIPTION
I have implemented the queryDbRow function to connectivityScore one or more query RankVectors against one DbRow's r RankVector, as well as tests for single query and two query cases.