### PR TITLE
Cache filters

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "LuciusCore"
 
-version in ThisBuild := "4.0.6"
+version in ThisBuild := "4.0.7"
 
 scalaVersion := "2.11.12"
 

--- a/src/main/scala/com/dataintuitive/luciuscore/api/AnnotatedIds.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/api/AnnotatedIds.scala
@@ -40,7 +40,7 @@ object AnnotatedIds extends ApiFunctionTrait {
 
     import sparkSession.implicits._
 
-    val CachedData(db, _, genesDb) = data.cachedData
+    val CachedData(db, _, genesDb, _) = data.cachedData
     val SpecificData(signatureQuery, limit, idsQuery, featuresQuery) = data.specificData
     implicit val genes = genesDb
 

--- a/src/main/scala/com/dataintuitive/luciuscore/api/BinnedCorrelation.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/api/BinnedCorrelation.scala
@@ -36,7 +36,7 @@ object BinnedCorrelation extends ApiFunctionTrait {
 
     import sparkSession.implicits._
 
-    val CachedData(db, _, genesDb) = data.cachedData
+    val CachedData(db, _, genesDb, _) = data.cachedData
     val SpecificData(signatureQuery, binsX, binsY, filters) = data.specificData
 
     implicit val genes = genesDb

--- a/src/main/scala/com/dataintuitive/luciuscore/api/CachedData.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/api/CachedData.scala
@@ -1,9 +1,9 @@
 package com.dataintuitive.luciuscore
 package api
 
-import com.dataintuitive.luciuscore.filters.Filters
+import com.dataintuitive.luciuscore.api.Filters.FiltersDB
 import model.v4._
 import genes._
 import org.apache.spark.sql.Dataset
 
-case class CachedData(db: Dataset[Perturbation], flatDb: Dataset[FlatDbRow], genes: GenesDB, filters:  Filters) extends Serializable
+case class CachedData(db: Dataset[Perturbation], flatDb: Dataset[FlatDbRow], genes: GenesDB, filters:  FiltersDB) extends Serializable

--- a/src/main/scala/com/dataintuitive/luciuscore/api/CachedData.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/api/CachedData.scala
@@ -1,9 +1,9 @@
 package com.dataintuitive.luciuscore
 package api
 
+import com.dataintuitive.luciuscore.filters.Filters
 import model.v4._
 import genes._
-
 import org.apache.spark.sql.Dataset
 
-case class CachedData(db: Dataset[Perturbation], flatDb: Dataset[FlatDbRow], genes: GenesDB) extends Serializable
+case class CachedData(db: Dataset[Perturbation], flatDb: Dataset[FlatDbRow], genes: GenesDB, filters:  Filters) extends Serializable

--- a/src/main/scala/com/dataintuitive/luciuscore/api/CheckSignature.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/api/CheckSignature.scala
@@ -34,7 +34,7 @@ object CheckSignature extends ApiFunctionTrait {
 
     implicit def signString(string: String) = new SignedString(string)
 
-    val CachedData(db, _, genesDb) = data.cachedData
+    val CachedData(db, _, genesDb, _) = data.cachedData
     val SpecificData(rawSignature) = data.specificData
     implicit val genes = genesDb
 

--- a/src/main/scala/com/dataintuitive/luciuscore/api/Compounds.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/api/Compounds.scala
@@ -38,7 +38,7 @@ object Compounds extends ApiFunctionTrait {
 
     import sparkSession.implicits._
 
-    val CachedData(db, _, genesDb) = data.cachedData
+    val CachedData(db, _, genesDb, _) = data.cachedData
     val SpecificData(compoundQuery, limit) = data.specificData
 
     implicit val genes = genesDb

--- a/src/main/scala/com/dataintuitive/luciuscore/api/Correlation.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/api/Correlation.scala
@@ -40,7 +40,7 @@ object Correlation extends ApiFunctionTrait {
 
     import sparkSession.implicits._
 
-    val CachedData(db, flatDb, genesDb) = data.cachedData
+    val CachedData(db, flatDb, genesDb, _) = data.cachedData
     val SpecificData(rawSignature1, rawSignature2, bins, filters) = data.specificData
     implicit val genes = genesDb
 

--- a/src/main/scala/com/dataintuitive/luciuscore/api/Filters.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/api/Filters.scala
@@ -16,7 +16,7 @@ object Filters extends ApiFunctionTrait {
   case class SpecificData()
 
   type JobOutput = Map[String, Any]
-  type Filters = Map[String, Array[String]]
+  type FiltersDB = Map[String, Array[String]]
 
   val infoMsg = "Filters available in the data (excluding orig_ filters)"
 
@@ -27,7 +27,7 @@ object Filters extends ApiFunctionTrait {
 
   def result(data: JobData) = data.cachedData.filters
 
-  def calculate(db: Dataset[Perturbation])(implicit sparkSession: SparkSession) = {
+  def calculate(db: Dataset[Perturbation])(implicit sparkSession: SparkSession): FiltersDB = {
 
     import sparkSession.implicits._
 

--- a/src/main/scala/com/dataintuitive/luciuscore/api/Filters.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/api/Filters.scala
@@ -16,20 +16,20 @@ object Filters extends ApiFunctionTrait {
   case class SpecificData()
 
   type JobOutput = Map[String, Any]
+  type Filters = Map[String, Array[String]]
 
   val infoMsg = "Filters available in the data (excluding orig_ filters)"
 
   val helpMsg =
-    "Return the filters and values used in the dataset.\nNo input is required. Pass null for parameters in Scala"
+    "Return the filters and values used in the dataset.\nNo input is required. Pass null for parameters in Scala. Only available after initialization."
 
   def header(data: JobData) = Map("key" -> "value").toString
 
-  def result(data: JobData)(implicit sparkSession: SparkSession) = {
+  def result(data: JobData) = data.cachedData.filters
+
+  def calculate(db: Dataset[Perturbation])(implicit sparkSession: SparkSession) = {
 
     import sparkSession.implicits._
-
-    val CachedData(db, _, genesDb) = data.cachedData
-    implicit val genes = genesDb
 
     val filterKeys = db.flatMap(_.filters.map(_.key)).distinct.collect
     val filterKeysWithoutOrig = filterKeys.filter( x => ! (x contains "orig_") )

--- a/src/main/scala/com/dataintuitive/luciuscore/api/GenerateSignature.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/api/GenerateSignature.scala
@@ -32,7 +32,7 @@ object GenerateSignature extends ApiFunctionTrait {
 
     import sparkSession.implicits._
 
-    val CachedData(db, _, genesDb) = data.cachedData
+    val CachedData(db, _, genesDb, _) = data.cachedData
     val SpecificData(pValue, pQuery) = data.specificData
 
     implicit val genes = genesDb

--- a/src/main/scala/com/dataintuitive/luciuscore/api/Statistics.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/api/Statistics.scala
@@ -34,7 +34,7 @@ object Statistics extends ApiFunctionTrait {
 
     import sparkSession.implicits._
 
-    val CachedData(_, flatDb, _) = data.cachedData
+    val CachedData(_, flatDb, _, _) = data.cachedData
 
     val compounds = Map(
       "total" -> flatDb

--- a/src/main/scala/com/dataintuitive/luciuscore/api/TargetToCompounds.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/api/TargetToCompounds.scala
@@ -35,7 +35,7 @@ object TargetToCompounds extends ApiFunctionTrait {
 
   def result(data:JobData)(implicit sparkSession: SparkSession):JobOutput = {
 
-    val CachedData(db, _, genesDb) = data.cachedData
+    val CachedData(db, _, genesDb, _) = data.cachedData
     val SpecificData(targetQuery, limit) = data.specificData
     implicit val genes = genesDb
 

--- a/src/main/scala/com/dataintuitive/luciuscore/api/Targets.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/api/Targets.scala
@@ -37,7 +37,7 @@ object Targets extends ApiFunctionTrait {
 
     import sparkSession.implicits._
 
-    val CachedData(db, _, genesDb) = data.cachedData
+    val CachedData(db, _, genesDb, _) = data.cachedData
     val SpecificData(targetQuery, limit) = data.specificData
     implicit val genes = genesDb
 

--- a/src/main/scala/com/dataintuitive/luciuscore/api/TopTable.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/api/TopTable.scala
@@ -41,7 +41,7 @@ object TopTable extends ApiFunctionTrait {
 
   def result(data: JobData)(implicit sparkSession: SparkSession) = {
 
-    val CachedData(db, _, genesDb) = data.cachedData
+    val CachedData(db, _, genesDb, _) = data.cachedData
     val SpecificData(head, tail, signatureQuery, featuresQuery, filters) = data.specificData
 
     implicit val genes = genesDb

--- a/src/main/scala/com/dataintuitive/luciuscore/api/TreatmentToPerturbations.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/api/TreatmentToPerturbations.scala
@@ -35,7 +35,7 @@ object TreatmentToPerturbations extends ApiFunctionTrait {
 
   def result(data: JobData)(implicit sparkSession: SparkSession) = {
 
-    val CachedData(db, _, genesDb) = data.cachedData
+    val CachedData(db, _, genesDb, _) = data.cachedData
     val SpecificData(pValue, compoundQuery, limit) = data.specificData
     implicit val genes = genesDb
 

--- a/src/main/scala/com/dataintuitive/luciuscore/api/Treatments.scala
+++ b/src/main/scala/com/dataintuitive/luciuscore/api/Treatments.scala
@@ -80,7 +80,7 @@ object Treatments extends ApiFunctionTrait {
 
     import sparkSession.implicits._
 
-    val CachedData(db, _, genesDb) = data.cachedData
+    val CachedData(db, _, genesDb, _) = data.cachedData
     val SpecificData(treatmentQuery, limit, like, trtType) = data.specificData
 
     implicit val genes = genesDb

--- a/src/test/scala/com/dataintuitive/luciuscore/TestData.scala
+++ b/src/test/scala/com/dataintuitive/luciuscore/TestData.scala
@@ -19,6 +19,7 @@ trait TestData extends BaseSparkContextSpec {
 
   val geneFile = "src/test/resources/GSE92742_Broad_LINCS_gene_info.txt"
   implicit val genesDB = new genes.GenesDB(io.GenesIO.loadGenesFromFile(sc, geneFile, "\t", featuresToExtract))
+  val filters = Map[String, Array[String]]() // TODO add actual filter data, placeholder for when tests might require it
 
   val profileLength = genesDB.genes.length
 

--- a/src/test/scala/com/dataintuitive/luciuscore/TestData.scala
+++ b/src/test/scala/com/dataintuitive/luciuscore/TestData.scala
@@ -1,5 +1,6 @@
 package com.dataintuitive.luciuscore
 
+import com.dataintuitive.luciuscore.api.Filters
 import model.v4._
 
 import org.apache.spark.sql.Dataset
@@ -19,7 +20,7 @@ trait TestData extends BaseSparkContextSpec {
 
   val geneFile = "src/test/resources/GSE92742_Broad_LINCS_gene_info.txt"
   implicit val genesDB = new genes.GenesDB(io.GenesIO.loadGenesFromFile(sc, geneFile, "\t", featuresToExtract))
-  val filters = Map[String, Array[String]]() // TODO add actual filter data, placeholder for when tests might require it
+  val filters: Filters.FiltersDB = Map.empty // TODO add actual filter data, placeholder for when tests might require it
 
   val profileLength = genesDB.genes.length
 

--- a/src/test/scala/com/dataintuitive/luciuscore/api/CheckSignatureTest.scala
+++ b/src/test/scala/com/dataintuitive/luciuscore/api/CheckSignatureTest.scala
@@ -18,21 +18,21 @@ class CheckSignatureTest extends AnyFlatSpec with Matchers with TestData {
   val emptyQuery = Nil
 
   "The result function" should "simply work" in {
-    val cData = CachedData(testData, flatData, genesDB)
+    val cData = CachedData(testData, flatData, genesDB, filters)
     val sData = SpecificData(correctQuery)
     val input = CheckSignature.JobData("version", cData, sData)
     CheckSignature.result(input).head should contain ("symbol" -> "MELK")
   }
 
   it should "deal with faulty queries as well" in {
-    val cData = CachedData(testData, flatData, genesDB)
+    val cData = CachedData(testData, flatData, genesDB, filters)
     val sData = SpecificData(faultyQuery)
     val input = CheckSignature.JobData("version", cData, sData)
     CheckSignature.result(input).head should contain ("inL1000" -> false)
   }
 
   it should "deal with empty queries" in {
-    val cData = CachedData(testData, flatData, genesDB)
+    val cData = CachedData(testData, flatData, genesDB, filters)
     val sData = SpecificData(emptyQuery)
     val input = CheckSignature.JobData("version", cData, sData)
     CheckSignature.result(input) shouldBe empty

--- a/src/test/scala/com/dataintuitive/luciuscore/api/StatisticsTest.scala
+++ b/src/test/scala/com/dataintuitive/luciuscore/api/StatisticsTest.scala
@@ -18,7 +18,7 @@ class StatisticsTest extends AnyFlatSpec with Matchers with TestData {
   val emptyQuery = Nil
 
   "The result function" should "simply work" in {
-    val input = Statistics.JobData("version", CachedData(testData, flatData, genesDB), SpecificData())
+    val input = Statistics.JobData("version", CachedData(testData, flatData, genesDB, filters), SpecificData())
     Statistics.result(input).size shouldBe 6
   }
 

--- a/src/test/scala/com/dataintuitive/luciuscore/api/TreatmentsTest.scala
+++ b/src/test/scala/com/dataintuitive/luciuscore/api/TreatmentsTest.scala
@@ -30,7 +30,7 @@ class TreatmentsTest extends AnyFlatSpec with Matchers with TestData {
   def inputGenerator(specificData:Treatments.SpecificData): Treatments.JobData =
       Treatments.JobData(
         "version",
-        CachedData(duplicateTreatmentData, flatData, genesDB),
+        CachedData(duplicateTreatmentData, flatData, genesDB, filters),
         specificData
       )
 


### PR DESCRIPTION
Add filter data to the runtime cached named objects

This data is (semi-)static but previously it needs to be calculated each time the filters API call is made
By caching this we only need to run this once at initialization and then just return it when the API call is made